### PR TITLE
Rollback to module-name import to fix defaults issue

### DIFF
--- a/src/sanitizeHtml.ts
+++ b/src/sanitizeHtml.ts
@@ -1,4 +1,4 @@
-import sanitize from "sanitize-html";
+import * as sanitize from "sanitize-html";
 
 /**
  * The reason for sanitization is because OpenAI does not need all of the HTML tags


### PR DESCRIPTION
Why ? 

Based on the official docs of sanitize-html we need do the following:

```
If esModuleInterop=true is not set in your tsconfig.json file, you have to import it with:

import * as sanitizeHtml from 'sanitize-html';
```



**Problem:**
 - Currently, we use default import (eg: import sanitizeHtml from 'sanitize-html') and the resulting js bundle currently would look for the following, which is wrong I assume :
<img width="553" alt="Screenshot 2024-07-18 at 13 23 03" src="https://github.com/user-attachments/assets/f1a5cfeb-fee1-4485-b24d-9f9087f8af51">


**Fix:**
- So a module-name import (* as module-name) would result in the right invocation like the following:
<img width="450" alt="Screenshot 2024-07-18 at 13 24 02" src="https://github.com/user-attachments/assets/7c1ea2c4-69e0-421d-a7ab-22ae982eb605">



**Connected issue**
https://github.com/lucgagan/auto-playwright/issues/36

