### PR TITLE
fix: sanitizeHtml import default is undefined

### DIFF
--- a/src/sanitizeHtml.ts
+++ b/src/sanitizeHtml.ts
@@ -1,5 +1,4 @@
-import sanitize from "sanitize-html";
-
+const sanitize = require('sanitize-html');
 /**
  * The reason for sanitization is because OpenAI does not need all of the HTML tags
  * to know how to interpret the website, e.g. it will not make a difference to AI if


### PR DESCRIPTION
If it is a `CommonJS` build method, you should use `require` to import it.

[sanitize-html](https://github.com/apostrophecms/sanitize-html)

![image](https://github.com/user-attachments/assets/27f09ac1-f1e8-43d9-b53f-4b64991a2489)

* https://github.com/lucgagan/auto-playwright/issues/36
* https://github.com/lucgagan/auto-playwright/issues/33