### PR TITLE
Fix package.json main entry and OpenAI API schema issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,14 @@
     ]
   },
   "name": "auto-playwright",
-  "main": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "sideEffects": false,
   "description": "Automate Playwright tests using ChatGPT.",
   "repository": {

--- a/src/createActions.ts
+++ b/src/createActions.ts
@@ -654,16 +654,25 @@ export const createActions = (
             type: ["string", "array"],
             description:
               "Select options with matching value attribute. Can be a string or an array for multi-select.",
+            items: {
+              type: "string"
+            }
           },
           label: {
             type: ["string", "array"],
             description:
               "Select options with matching visible text. Can be a string or an array for multi-select.",
+            items: {
+              type: "string"
+            }
           },
           index: {
             type: ["number", "array"],
             description:
               "Select options by their index (zero-based). Can be a number or an array for multi-select.",
+            items: {
+              type: "number"
+            }
           },
         },
       },


### PR DESCRIPTION
## Fix package.json main entry and OpenAI API schema issues

This PR addresses two important issues:

### 1. Package.json Module Resolution Issue
- Updated the `main` field in package.json to point to `./dist/index.js` instead of `./src/index.ts`
- Added `types` field pointing to `./dist/index.d.ts`
- Added `exports` field for better module resolution in modern JavaScript environments

This fixes the issue where TypeScript can't find the module when using the standard import syntax:
```typescript
import { auto } from "auto-playwright";
```
### 2. OpenAI API Schema Compatibility Issue

- Fixed the OpenAI API schema issue by adding the required `items` property to array types in function parameters
- This resolves the error: `Invalid schema for function 'locator_selectOption': In context=('properties', 'value', 'type', '1'), array schema missing items`
